### PR TITLE
Send heartbeat packet to client.

### DIFF
--- a/src/main/java/org/maxgamer/rs/network/protocol/Lobby637Protocol.java
+++ b/src/main/java/org/maxgamer/rs/network/protocol/Lobby637Protocol.java
@@ -23,7 +23,7 @@ public class Lobby637Protocol extends LobbyProtocol {
             @Override
             public void process(LobbyPlayer c, RSIncomingPacket p) throws Exception {
                 //Heartbeat packet.
-                //TODO: We should probably send some kind of response.
+                c.write(new RSOutgoingPacket(99));
             }
         });
 


### PR DESCRIPTION
This prevents client-side logout while in lobby. Not sure what the packet 99 does, but it seems to be ignored by the client. Tested and works.