### PR TITLE
fix(assets): calculate checksums without version bytes

### DIFF
--- a/src/main/java/org/maxgamer/rs/assets/AssetWeeder.java
+++ b/src/main/java/org/maxgamer/rs/assets/AssetWeeder.java
@@ -3,12 +3,10 @@ package org.maxgamer.rs.assets;
 import org.maxgamer.rs.assets.codec.asset.AssetReference;
 import org.maxgamer.rs.assets.codec.asset.AssetWriter;
 import org.maxgamer.rs.assets.codec.asset.IndexTable;
-import org.maxgamer.rs.assets.formats.ItemFormat;
 import org.maxgamer.rs.assets.protocol.MapCache;
 import org.maxgamer.rs.util.Log;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,7 +18,6 @@ import java.util.Map;
 public class AssetWeeder {
     public static void weed(AssetStorage storage) throws IOException {
         evictMaps(storage);
-        addLickToCoins(storage);
     }
 
     /**
@@ -66,20 +63,5 @@ public class AssetWeeder {
                     "They're being patched out of the cache now.");
             writer.commit();
         }
-    }
-
-    public static void addLickToCoins(AssetStorage storage) throws IOException {
-        final int id = 995; // Coins
-        MultiAsset a = storage.archive(IDX.ITEMS, id >> 8);
-        ByteBuffer bb = a.get(id & 0xFF);
-
-        ItemFormat format = new ItemFormat();
-        format.decode(bb.asReadOnlyBuffer());
-
-        format.setInventoryOption(3, "Lick");
-
-        storage.writer(IDX.ITEMS)
-                .write(id >> 8, id & 0xFF, format.encode())
-                .commit();
     }
 }

--- a/src/main/java/org/maxgamer/rs/assets/AssetWeeder.java
+++ b/src/main/java/org/maxgamer/rs/assets/AssetWeeder.java
@@ -1,6 +1,5 @@
 package org.maxgamer.rs.assets;
 
-import org.maxgamer.rs.assets.codec.asset.Asset;
 import org.maxgamer.rs.assets.codec.asset.AssetReference;
 import org.maxgamer.rs.assets.codec.asset.AssetWriter;
 import org.maxgamer.rs.assets.codec.asset.IndexTable;
@@ -79,17 +78,8 @@ public class AssetWeeder {
 
         format.setInventoryOption(3, "Lick");
 
-        ByteBuffer encoded = format.encode();
-        AssetReference reference = storage.properties(IDX.ITEMS, id >> 8);
-        AssetReference newRef = new AssetReference(reference.getIdentifier(), reference.getCRC(), reference.getWhirlpool(), reference.getVersion() + 1, reference.getChildren());
-        Asset asset = storage.read(IDX.ITEMS, id >> 8);
-        a.put(id & 0xFF, encoded);
-
-        asset.setPayload(a.encode());
-        asset.setVersion(newRef.getVersion());
-
         storage.writer(IDX.ITEMS)
-                .write(id >> 8, newRef, asset)
+                .write(id >> 8, id & 0xFF, format.encode())
                 .commit();
     }
 }

--- a/src/main/java/org/maxgamer/rs/assets/CachedAssetStorage.java
+++ b/src/main/java/org/maxgamer/rs/assets/CachedAssetStorage.java
@@ -54,6 +54,8 @@ public class CachedAssetStorage extends AssetStorage {
 
         WeakReference<MultiAsset> reference = index.get(file);
         if(reference != null) {
+            // TODO: Modifying this outside of this code is possible, and doing so will alter
+            // TODO: what appears to be written to disk, before committing it!
             MultiAsset asset = reference.get();
 
             if(asset != null) return asset;

--- a/src/main/java/org/maxgamer/rs/assets/CachedAssetStorage.java
+++ b/src/main/java/org/maxgamer/rs/assets/CachedAssetStorage.java
@@ -54,18 +54,20 @@ public class CachedAssetStorage extends AssetStorage {
 
         WeakReference<MultiAsset> reference = index.get(file);
         if(reference != null) {
-            // TODO: Modifying this outside of this code is possible, and doing so will alter
-            // TODO: what appears to be written to disk, before committing it!
             MultiAsset asset = reference.get();
 
-            if(asset != null) return asset;
+            // We don't return the asset, we return a copy of it. Such that, if one copy
+            // is modified, and a second copy is retrieved, the second copy will not show
+            // the first copy's changes, unless the first copy was written to disk!
+            if(asset != null) return asset.copy();
         }
 
         // We've got no cached version, so fetch it and cache it
         MultiAsset asset = super.archive(idx, file);
         index.put(file, new WeakReference<>(asset));
 
-        return asset;
+        // We return a copy so that nobody can modify our internal version
+        return asset.copy();
     }
 
     /**

--- a/src/main/java/org/maxgamer/rs/assets/CachedAssetStorage.java
+++ b/src/main/java/org/maxgamer/rs/assets/CachedAssetStorage.java
@@ -77,5 +77,4 @@ public class CachedAssetStorage extends AssetStorage {
         cache = new HashMap<>();
         cacheLastCleared = System.currentTimeMillis();
     }
-
 }

--- a/src/main/java/org/maxgamer/rs/assets/MultiAsset.java
+++ b/src/main/java/org/maxgamer/rs/assets/MultiAsset.java
@@ -184,6 +184,17 @@ public class MultiAsset extends Codec {
     }
 
     /**
+     * Create a copy of this MultiAsset. The copy can be modified without modifying this asset.
+     * @return the copy
+     */
+    public MultiAsset copy() {
+        MultiAsset that = new MultiAsset(reference);
+        that.entries = new TreeMap<>(this.entries);
+
+        return that;
+    }
+
+    /**
      * Fetch an iterator for iterating over the files inside this asset
      * @return the iterator
      */

--- a/src/main/java/org/maxgamer/rs/assets/MultiAsset.java
+++ b/src/main/java/org/maxgamer/rs/assets/MultiAsset.java
@@ -195,6 +195,17 @@ public class MultiAsset extends Codec {
     }
 
     /**
+     * Create a copy of this MultiAsset. The copy can be modified without modifying this asset.
+     * @return the copy
+     */
+    public MultiAsset copy(AssetReference reference) {
+        MultiAsset that = new MultiAsset(reference);
+        that.entries = new TreeMap<>(this.entries);
+
+        return that;
+    }
+
+    /**
      * Fetch an iterator for iterating over the files inside this asset
      * @return the iterator
      */

--- a/src/main/java/org/maxgamer/rs/assets/codec/asset/AssetReference.java
+++ b/src/main/java/org/maxgamer/rs/assets/codec/asset/AssetReference.java
@@ -69,6 +69,15 @@ public class AssetReference {
         return children.clone();
     }
 
+    public int indexOf(int id) {
+        for(int i = 0; i < children.length; i++) {
+            SubAssetReference child = children[i];
+            if(child.getId() == id) return i;
+        }
+
+        return -1;
+    }
+
     /**
      * The number of children this file has. If this file has no children,
      * then this value is 1 (Eg, it's just the one file).

--- a/src/main/java/org/maxgamer/rs/assets/codec/asset/AssetWriter.java
+++ b/src/main/java/org/maxgamer/rs/assets/codec/asset/AssetWriter.java
@@ -122,10 +122,20 @@ public class AssetWriter {
         // Take a read only copy for writing later
         ByteBuffer content = asset.encode();
 
+        if(asset.getVersion() != -1) {
+            // We don't checksum or hash the version
+            content.limit(content.limit() - 2);
+        }
+
         // We don't want to modify the original, in case it was pulled from the cache (until we commit)
         reference = reference.copy();
         reference.whirlpool = whirlpool(content);
         reference.crc = crc32(content);
+
+        if(asset.getVersion() != -1) {
+            // Reset limit
+            content.limit(content.limit() + 2);
+        }
 
         // We assert that asset.getVersion() == reference.getVersion()
         Assert.isTrue(asset.getVersion() == -1 || reference.getVersion() == asset.getVersion(), "Asset version must equal reference version, if set");

--- a/src/main/java/org/maxgamer/rs/assets/codec/asset/AssetWriter.java
+++ b/src/main/java/org/maxgamer/rs/assets/codec/asset/AssetWriter.java
@@ -1,12 +1,15 @@
 package org.maxgamer.rs.assets.codec.asset;
 
 import net.openrs.util.crypto.Whirlpool;
-import org.maxgamer.rs.util.Assert;
 import org.maxgamer.rs.assets.DataTable;
+import org.maxgamer.rs.assets.MultiAsset;
+import org.maxgamer.rs.util.Assert;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.Map;
 import java.util.zip.CRC32;
 
@@ -145,6 +148,246 @@ public class AssetWriter {
         return this;
     }
 
+    /**
+     * Appends the given write to the list of writes to perform when {@link #commit()} is called. This does not
+     * modify the given {@link ByteBuffer}, as it takes a read-only copy for later. This increments the version
+     * on the asset, or takes some sane defaults if the asset doesn't exist.
+     *
+     * @param id the id of the file to write to
+     * @param asset the asset to write for the file
+     * @return this
+     */
+    public AssetWriter write(int id, Asset asset) throws IOException {
+        Assert.isPositive(id, "File ID must be positive");
+        Assert.notNull(asset, "Asset may not be null");
+
+        AssetReference reference = this.indexTable.getReferences().get(id);
+
+        if(reference == null) {
+            int version = asset.getVersion();
+            if(version == -1) {
+                reference = AssetReference.create(1);
+            } else {
+                reference = AssetReference.create(version);
+            }
+        } else {
+            reference = new AssetReference(reference.getIdentifier(), 0, null, reference.getVersion() + 1, reference.getChildren());
+            asset.setVersion(reference.getVersion());
+        }
+
+        return write(id, reference, asset);
+    }
+
+    /**
+     * Appends the given write to the list of writes to perform when {@link #commit()} is called. This does not
+     * modify the given {@link ByteBuffer}, as it takes a read-only copy for later. This increments the version
+     * on the asset, or takes some sane defaults if it doesn't exist.
+     *
+     * @param id the id of the file to write to
+     * @param multi the assets to write for the file
+     * @return this
+     */
+    public AssetWriter write(int id, MultiAsset multi) throws IOException {
+        Assert.isPositive(id, "File ID must be positive");
+        Assert.notNull(multi, "MultiAsset may not be null");
+
+        Asset asset;
+        XTEAKey key = xteas.getKey(indexTable.getIdx(), id);
+        try {
+            asset = new Asset(key, dataTable.read(id));
+        } catch (FileNotFoundException e) {
+            // Asset doesn't exist yet
+            asset = new Asset(key);
+        }
+
+        AssetReference reference = this.indexTable.getReferences().get(id);
+        if(reference == null) {
+            SubAssetReference[] children = new SubAssetReference[multi.size()];
+            int index = 0;
+            Iterator<Map.Entry<Integer, ByteBuffer>> mit = multi.iterator();
+
+            while(mit.hasNext()) {
+                Map.Entry<Integer, ByteBuffer> entry = mit.next();
+                children[index++] = new SubAssetReference(entry.getKey(), 0);
+            }
+
+            if(asset.getVersion() == -1) {
+                reference = AssetReference.create(1, children);
+            } else {
+                reference = AssetReference.create(asset.getVersion() + 1, children);
+            }
+        }
+
+        multi = multi.copy(reference);
+        Assert.isTrue(multi.isComplete(), "Expect MultiAsset to be complete");
+        asset.setPayload(multi.encode());
+        asset.setVersion(reference.getVersion());
+
+        return write(id, reference, asset);
+    }
+
+    /**
+     * Appends the given write to the list of writes to perform when {@link #commit()} is called. This does not
+     * modify the given {@link ByteBuffer}, as it takes a read-only copy for later. This increments the version
+     * on the asset, or takes some sane defaults if it doesn't exist.
+     *
+     * @param id the id of the file to write to
+     * @param subAsset the id (not index) of the sub asset to write to
+     * @param content the contents of the sub asset
+     * @return this
+     */
+    public AssetWriter write(int id, int subAsset, ByteBuffer content) throws IOException {
+        Assert.isPositive(id, "File ID must be positive");
+        Assert.isPositive(subAsset, "Sub Asset Id must be positive");
+        Assert.notNull(content, "Content may not be null");
+
+        AssetReference reference;
+        Asset asset;
+        MultiAsset multi;
+
+        if(writes.containsKey(id)) {
+            // We've got an existing write request. We need to operate off of it, instead
+            // of the data currently written to the cache
+            WriteRequest request = this.writes.get(id);
+
+            if(request == null) {
+                // The existing write request is a delete request. We make our previous reference
+                // a dummy one at version 0 with no children
+                reference = AssetReference.create(0);
+                asset = new Asset(xteas.getKey(indexTable.getIdx(), id));
+                multi = new MultiAsset(reference);
+            } else {
+                // The existing write request can be modified
+                reference = request.reference;
+                asset = new Asset(request.key, request.content);
+                multi = new MultiAsset(reference, asset.getPayload());
+            }
+        } else {
+            // We've got no existing write request (or it's a delete request). It's okay
+            // to read from the cache
+            reference = indexTable.getReferences().get(id);
+            if(reference == null) {
+                reference = AssetReference.create(0);
+                asset = new Asset(xteas.getKey(indexTable.getIdx(), id));
+                multi = new MultiAsset(reference);
+            } else {
+                asset = new Asset(xteas.getKey(indexTable.getIdx(), id), dataTable.read(id));
+                multi = new MultiAsset(reference, asset.getPayload());
+            }
+        }
+
+        // Append the new child to the existing multi asset, increment the versions, and save.
+        SubAssetReference[] children;
+        int index = reference.indexOf(subAsset);
+        if(index == -1) {
+            // We're adding a new child
+            children = new SubAssetReference[reference.getChildCount() + 1];
+        } else {
+            // We're replacing an existing child
+            children = new SubAssetReference[reference.getChildCount()];
+        }
+
+        for(int i = 0; i < reference.getChildCount(); i++) {
+            children[i] = reference.getChild(i);
+        }
+
+        if(index == -1) index = children.length - 1;
+        children[index] = new SubAssetReference(subAsset, 0);
+        reference = new AssetReference(reference.getIdentifier(), 0, null, reference.getVersion() + 1, children);
+
+        multi.put(subAsset, content.asReadOnlyBuffer());
+        multi = multi.copy(reference);
+        Assert.isTrue(multi.isComplete(), "Expect multi asset to be complete");
+        asset.setPayload(multi.encode());
+        asset.setVersion(reference.getVersion());
+
+        return write(id, reference, asset);
+    }
+
+    /**
+     * Delete an existing sub-asset. This doesn't delete the parent file.
+     * @param id the id of the parent
+     * @param subAsset the id of the child
+     * @return this
+     * @throws IOException if the file can't be deleted
+     */
+    public AssetWriter delete(int id, int subAsset) throws IOException {
+        Assert.isPositive(id, "File ID must be positive");
+        Assert.isPositive(subAsset, "Sub Asset ID must be positive");
+
+        AssetReference reference;
+        Asset asset;
+        MultiAsset multi;
+
+        if(writes.containsKey(id)) {
+            // We've got an existing write request. We need to operate off of it, instead
+            // of the data currently written to the cache
+            WriteRequest request = this.writes.get(id);
+
+            if(request == null) {
+                // The existing write request is a delete request. We make our previous reference
+                // a dummy one at version 0 with no children
+                reference = AssetReference.create(0);
+                asset = new Asset(xteas.getKey(indexTable.getIdx(), id));
+                multi = new MultiAsset(reference);
+            } else {
+                // The existing write request can be modified
+                reference = request.reference;
+                asset = new Asset(request.key, request.content);
+                multi = new MultiAsset(reference, asset.getPayload());
+            }
+        } else {
+            // We've got no existing write request (or it's a delete request). It's okay
+            // to read from the cache
+            reference = indexTable.getReferences().get(id);
+            if(reference == null) {
+                reference = AssetReference.create(0);
+                asset = new Asset(xteas.getKey(indexTable.getIdx(), id));
+                multi = new MultiAsset(reference);
+            } else {
+                asset = new Asset(xteas.getKey(indexTable.getIdx(), id), dataTable.read(id));
+                multi = new MultiAsset(reference, asset.getPayload());
+            }
+        }
+
+        // Append the new child to the existing multi asset, increment the versions, and save.
+        SubAssetReference[] children;
+        int index = reference.indexOf(subAsset);
+        if(index == -1) {
+            throw new FileNotFoundException("Subfile at " + id + ", " + subAsset + ") doesn't exist");
+        } else {
+            // We're deleting an existing child
+            children = new SubAssetReference[reference.getChildCount() - 1];
+        }
+
+        // Copy all of the previous children, skipping the deleted one
+        for(int i = 0; i < index; i++) {
+            children[i] = reference.getChild(i);
+        }
+
+        for(int i = index; i < reference.getChildCount() - 1; i++) {
+            children[i] = reference.getChild(i + 1);
+        }
+
+        reference = new AssetReference(reference.getIdentifier(), 0, null, reference.getVersion() + 1, children);
+
+        // Delete the data from the asset
+        multi.put(subAsset, null);
+        multi = multi.copy(reference);
+
+        Assert.isTrue(multi.isComplete(), "Expect multi asset to be complete");
+        asset.setPayload(multi.encode());
+        asset.setVersion(reference.getVersion());
+
+        return write(id, reference, asset);
+    }
+
+    /**
+     * Deletes the given asset
+     * @param id the asset to delete
+     * @return this
+     * @throws IOException if the asset can't be deleted
+     */
     public AssetWriter delete(int id) throws IOException {
         Assert.isPositive(id, "File ID must be positive");
 

--- a/src/main/java/org/maxgamer/rs/assets/formats/Format.java
+++ b/src/main/java/org/maxgamer/rs/assets/formats/Format.java
@@ -1,0 +1,160 @@
+package org.maxgamer.rs.assets.formats;
+
+import org.maxgamer.rs.assets.codec.Codec;
+import org.maxgamer.rs.util.Log;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Format class for decoding information from a codec
+ *
+ * @author netherfoam
+ */
+public abstract class Format extends Codec {
+    /**
+     * Represents a packet whose format could be read, but content is unknown. A preserved
+     * packet will be re-encoded, though its meaning is unknown.
+     */
+    private static class UnknownPacket {
+        /**
+         * The opcode of the packet
+         */
+        private final int opcode;
+
+        /**
+         * The content in the packet
+         */
+        private final byte[] content;
+
+        /**
+         * Constructs a new unknown packet for preservation
+         * @param opcode the opcode (byte)
+         * @param content the content
+         */
+        public UnknownPacket(int opcode, byte[] content) {
+            if(opcode <= 0 || opcode > 255) throw new IllegalArgumentException("Opcodes are 1-255");
+
+            this.opcode = opcode;
+            this.content = content;
+        }
+    }
+
+    public class Stasis {
+        /**
+         * The buffer we're monitoring
+         */
+        private ByteBuffer buffer;
+
+        /**
+         * The position of the buffer when begin() was invoked
+         */
+        private int startPosition = -1;
+
+        /**
+         * The position of the buffer when preserve() was invoked
+         */
+        private int endPosition = -1;
+
+        /**
+         * Constructs a new stasis preserver for the given buffer
+         */
+        private Stasis(ByteBuffer buffer) {
+            this.buffer = buffer;
+        }
+
+        /**
+         * Marks the beginning of the stasis block
+         */
+        public void begin() {
+            if(startPosition != -1) throw new IllegalStateException("Stasis already begun");
+
+            this.startPosition = buffer.position();
+        }
+
+        /**
+         * Marks the end of the stasis block
+         */
+        public void preserve() {
+            if(startPosition == -1) throw new IllegalStateException("Stasis hasn't begun");
+            if(endPosition != -1) throw new IllegalStateException("Stasis already ended");
+
+            endPosition = buffer.position();
+        }
+
+        /**
+         * Returns true if the stasis block is ready for preservation, false if it was never finished
+         * @return true if the stasis block is ready for preservation
+         */
+        public boolean isFinished() {
+            if(endPosition == -1) return false;
+
+            return true;
+        }
+
+        /**
+         * The block of data that was preserved. This is never null, but may be empty.
+         * @return the data preserved
+         * @throws IllegalStateException if the block was never preserved
+         */
+        public byte[] get() {
+            if(!isFinished()) throw new IllegalStateException("Stasis was never finished");
+
+            byte[] data = new byte[endPosition - startPosition];
+
+            int pos = buffer.position();
+
+            buffer.position(startPosition);
+            buffer.get(data);
+            buffer.position(pos);
+
+            return data;
+        }
+    }
+
+    /**
+     * The list of packets which were preserved, because we don't know what they are.
+     */
+    private List<UnknownPacket> unknownPackets = new ArrayList<>();
+
+    @Override
+    public final void decode(ByteBuffer bb) throws IOException {
+        int opcode;
+
+        while((opcode = bb.get() & 0xFF) != 0) {
+            Stasis stasis = new Stasis(bb);
+            stasis.begin();
+            decode(opcode, bb, stasis);
+
+            if(stasis.isFinished()) {
+                unknownPackets.add(new UnknownPacket(opcode, stasis.get()));
+            }
+        }
+
+        if (bb.remaining() > 0) {
+            Log.warning("ItemDefinition Buffer remaining " + bb.remaining());
+        }
+    }
+
+    @Override
+    public final ByteBuffer encode() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream(128);
+        encode(out);
+
+        for(UnknownPacket packet : unknownPackets) {
+            out.write((byte) packet.opcode);
+            out.write(packet.content);
+        }
+
+        // End of file marker
+        out.write((byte) 0);
+
+        return ByteBuffer.wrap(out.toByteArray());
+    }
+
+    public abstract void encode(ByteArrayOutputStream out) throws IOException;
+    public abstract void decode(int opcode, ByteBuffer buffer, Stasis stasis) throws IOException;
+}

--- a/src/main/java/org/maxgamer/rs/assets/formats/ItemFormat.java
+++ b/src/main/java/org/maxgamer/rs/assets/formats/ItemFormat.java
@@ -1,89 +1,36 @@
 package org.maxgamer.rs.assets.formats;
 
-import org.maxgamer.rs.model.item.AmmoType;
-import org.maxgamer.rs.model.item.ItemAmmoType;
 import org.maxgamer.rs.model.item.condition.ItemMetadataSet;
-import org.maxgamer.rs.model.item.weapon.EquipmentType;
 import org.maxgamer.rs.util.BufferUtils;
 
-import javax.persistence.Column;
-import javax.persistence.Id;
-import javax.persistence.OneToMany;
-import javax.persistence.OneToOne;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
 
 /**
  * @author netherfoam
  */
 public class ItemFormat extends Format {
-    @Id
-    protected int id;
-    @Column
-    protected String name;
-    /* Cache Values */
     protected transient int interfaceModelId;
-    // The IDs of the models to paint on characters (Eg on the real character,
-    // not an interface)
+
+    // The IDs of the models to paint on characters (Eg on the real character, not an interface)
     protected transient int maleWornModelId1 = -1;
     protected transient int maleWornModelId2 = -1;
     protected transient int femaleWornModelId1 = -1;
     protected transient int femaleWornModelId2 = -1;
-    @Column
-    private String examine;
-    @Column
-    private boolean tradeable;
-    @Column
-    private boolean droppable;
-    @Column
-    private long maxStack;
-    @Column
-    private int value;
-    @Column
-    private int lowAlchemy;
-    @Column
-    private int highAlchemy;
-    @Column
-    private double weight;
-    @OneToOne(mappedBy = "item")
-    private EquipmentType weapon;
-    @OneToMany(mappedBy = "weapon")
-    private List<ItemAmmoType> ammo = new LinkedList<>();
-    @OneToOne(mappedBy = "item")
-    private AmmoType projectile;
-    /*
-     * private int modelZoom; private int modelRotation1; private int
-     * modelRotation2;
-     */
+    protected String name;
+
     private transient int modelOffset1;
     private transient int modelOffset2;
-    /* private int stackable; */
-    /* private int value; */
     private transient boolean membersOnly;
     private transient String[] groundOptions = new String[]{null, "Take", null, null, null};
     private transient String[] inventoryOptions = new String[]{null, null, null, null, "Drop"};
     private transient boolean unnoted;
-
-    /*
-     * private int[] originalModelColors; private int[] modifiedModelColors;
-     * private int[] textureColour1; private int[] textureColour2; private
-     * byte[] unknownArray1; private int[] unknownArray2;
-     */
-    /*
-     * private int colourEquip1; private int colourEquip2; private int certId;
-     * private int certTemplateId;
-     */
     private transient int[] stackIds;
     private transient int[] stackAmounts;
     private transient int teamId;
     private transient HashMap<Integer, Object> clientScriptData;
-    /*
-     * private int lendId; private int lendTemplateId;
-     */
     private transient ItemMetadataSet flags;
 
     private static void discard(ByteBuffer bb, int op, int bytes) {

--- a/src/main/java/org/maxgamer/rs/assets/formats/ItemFormat.java
+++ b/src/main/java/org/maxgamer/rs/assets/formats/ItemFormat.java
@@ -1,0 +1,391 @@
+package org.maxgamer.rs.assets.formats;
+
+import org.maxgamer.rs.model.item.AmmoType;
+import org.maxgamer.rs.model.item.ItemAmmoType;
+import org.maxgamer.rs.model.item.condition.ItemMetadataSet;
+import org.maxgamer.rs.model.item.weapon.EquipmentType;
+import org.maxgamer.rs.util.BufferUtils;
+
+import javax.persistence.Column;
+import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import javax.persistence.OneToOne;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+
+/**
+ * @author netherfoam
+ */
+public class ItemFormat extends Format {
+    @Id
+    protected int id;
+    @Column
+    protected String name;
+    /* Cache Values */
+    protected transient int interfaceModelId;
+    // The IDs of the models to paint on characters (Eg on the real character,
+    // not an interface)
+    protected transient int maleWornModelId1 = -1;
+    protected transient int maleWornModelId2 = -1;
+    protected transient int femaleWornModelId1 = -1;
+    protected transient int femaleWornModelId2 = -1;
+    @Column
+    private String examine;
+    @Column
+    private boolean tradeable;
+    @Column
+    private boolean droppable;
+    @Column
+    private long maxStack;
+    @Column
+    private int value;
+    @Column
+    private int lowAlchemy;
+    @Column
+    private int highAlchemy;
+    @Column
+    private double weight;
+    @OneToOne(mappedBy = "item")
+    private EquipmentType weapon;
+    @OneToMany(mappedBy = "weapon")
+    private List<ItemAmmoType> ammo = new LinkedList<>();
+    @OneToOne(mappedBy = "item")
+    private AmmoType projectile;
+    /*
+     * private int modelZoom; private int modelRotation1; private int
+     * modelRotation2;
+     */
+    private transient int modelOffset1;
+    private transient int modelOffset2;
+    /* private int stackable; */
+    /* private int value; */
+    private transient boolean membersOnly;
+    private transient String[] groundOptions = new String[]{null, "Take", null, null, null};
+    private transient String[] inventoryOptions = new String[]{null, null, null, null, "Drop"};
+    private transient boolean unnoted;
+
+    /*
+     * private int[] originalModelColors; private int[] modifiedModelColors;
+     * private int[] textureColour1; private int[] textureColour2; private
+     * byte[] unknownArray1; private int[] unknownArray2;
+     */
+    /*
+     * private int colourEquip1; private int colourEquip2; private int certId;
+     * private int certTemplateId;
+     */
+    private transient int[] stackIds;
+    private transient int[] stackAmounts;
+    private transient int teamId;
+    private transient HashMap<Integer, Object> clientScriptData;
+    /*
+     * private int lendId; private int lendTemplateId;
+     */
+    private transient ItemMetadataSet flags;
+
+    private static void discard(ByteBuffer bb, int op, int bytes) {
+        for (int i = 0; i < bytes; i++) {
+            bb.get();
+        }
+    }
+
+    @Override
+    public void decode(int opcode, ByteBuffer buffer, Stasis stasis) throws IOException {
+        switch (opcode) {
+            case 4:
+            /* modelZoom = */
+                discard(buffer, opcode, 2);/* & 0xFFFF */
+                stasis.preserve();
+                break;
+            case 5:
+            /* modelRotation1 = */
+                discard(buffer, opcode, 2);/* & 0xFFFF */
+                stasis.preserve();
+                break;
+            case 6:
+            /* modelRotation2 = */
+                discard(buffer, opcode, 2);/* & 0xFFFF */
+                stasis.preserve();
+                break;
+            case 11:
+                //stackable = true;
+                stasis.preserve();
+                break;
+            case 12:
+            /* value = */
+                buffer.getInt();
+                stasis.preserve();
+                break;
+            case 23:
+                maleWornModelId1 = buffer.getShort() & 0xFFFF;
+                stasis.preserve();
+                break;
+            case 25:
+                maleWornModelId2 = buffer.getShort() & 0xFFFF;
+                stasis.preserve();
+                break;
+            case 26:
+                femaleWornModelId2 = buffer.getShort() & 0xFFFF;
+                stasis.preserve();
+                break;
+            case 35:
+            case 36:
+            case 37:
+            case 38:
+            case 39:
+                inventoryOptions[opcode - 35] = BufferUtils.readRS2String(buffer);
+                break;
+            case 40: {
+                int length = buffer.get() & 0xFF;
+                int[] originalModelColors = new int[length];
+                int[] modifiedModelColors = new int[length];
+                for (int index = 0; index < length; index++) {
+                    originalModelColors[index] = buffer.getShort() & 0xFFFF;
+                    modifiedModelColors[index] = buffer.getShort() & 0xFFFF;
+                }
+                stasis.preserve();
+                break;
+            }
+            case 41: {
+                int length = buffer.get() & 0xFF;
+                int[] textureColour1 = new int[length];
+                int[] textureColour2 = new int[length];
+                for (int index = 0; index < length; index++) {
+                    textureColour1[index] = buffer.getShort() & 0xFFFF;
+                    textureColour2[index] = buffer.getShort() & 0xFFFF;
+                }
+                stasis.preserve();
+                break;
+            }
+            case 42: {
+                int length = buffer.get() & 0xFF;
+                byte[] unknownArray1 = new byte[length];
+                for (int index = 0; index < length; index++) {
+                    unknownArray1[index] = buffer.get();
+                }
+                stasis.preserve();
+                break;
+            }
+            case 65:
+                unnoted = true;
+                stasis.preserve();
+                break;
+            case 78:
+            /* colourEquip1 = */
+                buffer.getShort()/* & 0xFFFF */;
+                stasis.preserve();
+                break;
+            case 79:
+            /* colourEquip2 = */
+                buffer.getShort()/* & 0xFFFF */;
+                stasis.preserve();
+                break;
+            case 91:
+                // buffer.getShort();
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 98:
+            /* certTemplateId = */
+                discard(buffer, opcode, 2); /* & 0xFFFF */
+                stasis.preserve();
+                break;
+            case 110:
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 111:
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 115:
+                teamId = buffer.get() & 0xFF;
+                stasis.preserve();
+                break;
+            case 122:
+            /* lendTemplateId = */
+                buffer.getShort()/* & 0xFFFF */;
+                stasis.preserve();
+                break;
+            case 130:
+                discard(buffer, opcode, 1);
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 139:
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 249: {
+                int length = buffer.get() & 0xFF;
+                if (clientScriptData == null) {
+                    clientScriptData = new HashMap<>();
+                }
+                for (int index = 0; index < length; index++) {
+                    boolean stringInstance = buffer.get() == 1;
+                    int key = BufferUtils.getTriByte(buffer);
+                    Object value = stringInstance ? BufferUtils
+                            .readRS2String(buffer) : buffer.getInt();
+                    clientScriptData.put(key, value);
+                }
+                stasis.preserve();
+                break;
+            }
+            case 140:
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 134:
+                discard(buffer, opcode, 1);
+                stasis.preserve();
+                break;
+            case 132: {
+                int length = buffer.get() & 0xFF;
+                int[] unknownArray2 = new int[length];
+                for (int index = 0; index < length; index++) {
+                    unknownArray2[index] = buffer.getShort() & 0xFFFF;
+                }
+                stasis.preserve();
+                break;
+            }
+            case 129:
+            case 128:
+            case 127:
+                discard(buffer, opcode, 1);
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 126:
+            case 125:
+                buffer.get();
+                buffer.get();
+                buffer.get();
+                stasis.preserve();
+                break;
+            case 121:
+            /* lendId = */
+                buffer.getShort()/* & 0xFFFF */;
+                stasis.preserve();
+                break;
+            case 114:
+                buffer.get();
+                stasis.preserve();
+                break;
+            case 113:
+                buffer.get();
+                stasis.preserve();
+                break;
+            case 112:
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 100:
+            case 101:
+            case 102:
+            case 103:
+            case 104:
+            case 105:
+            case 106:
+            case 107:
+            case 108:
+            case 109:
+                if (stackIds == null) {
+                    stackIds = new int[10];
+                    stackAmounts = new int[10];
+                }
+                stackIds[opcode - 100] = buffer.getShort() & 0xFFFF;
+                stackAmounts[opcode - 100] = buffer.getShort() & 0xFFFF;
+                stasis.preserve();
+                break;
+            case 96:
+                buffer.get();
+                // certId = buffer.getShort();
+                stasis.preserve();
+                break;
+            case 97:
+            /* certTemplateId = */
+                buffer.getShort();
+                stasis.preserve();
+                break;
+            case 95:
+            case 93:
+            case 92:
+            case 90: // unknown
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 30:
+            case 31:
+            case 32:
+            case 33:
+            case 34:
+                groundOptions[opcode - 30] = BufferUtils.readRS2String(buffer);
+                stasis.preserve();
+                break;
+            case 24:
+                femaleWornModelId1 = buffer.getShort();
+                stasis.preserve();
+                break;
+            case 18:
+                discard(buffer, opcode, 2);
+                stasis.preserve();
+                break;
+            case 16:
+                membersOnly = true;
+                stasis.preserve();
+                break;
+            case 8:
+                modelOffset2 = buffer.getShort() & 0xFFFF;
+                if (modelOffset2 > 32767)
+                    modelOffset2 -= 65536;
+                modelOffset2 <<= 0;
+                stasis.preserve();
+                break;
+            case 7:
+                modelOffset1 = buffer.getShort() & 0xFFFF;
+                if (modelOffset1 > 32767)
+                    modelOffset1 -= 65536;
+                modelOffset1 <<= 0;
+                stasis.preserve();
+                break;
+            case 2:
+                name = BufferUtils.readRS2String(buffer);
+                stasis.preserve();
+                break;
+            case 1:
+                interfaceModelId = buffer.getShort() & 0xFFFF;
+                stasis.preserve();
+                break;
+            default:
+                throw new IOException("Unknown opcode " + opcode);
+        }
+    }
+
+    @Override
+    public void encode(ByteArrayOutputStream out) throws IOException {
+        // No extra data written here, yet.
+        for(int i = 0; i < 5; i++) {
+            String option = inventoryOptions[i];
+
+            if(option == null) continue;
+            if(i == 4 && "Drop".equals(option)) continue;
+
+            out.write((byte) (i + 35));
+            for(int j = 0; j < option.length(); j++) {
+                out.write((byte) option.charAt(j));
+            }
+            out.write((byte) 0);
+        }
+    }
+
+    public void setInventoryOption(int id, String option) {
+        this.inventoryOptions[id] = option;
+    }
+
+    public String getInventoryOption(int i) {
+        return inventoryOptions[i];
+    }
+}

--- a/src/main/java/org/maxgamer/rs/assets/formats/NPCFormat.java
+++ b/src/main/java/org/maxgamer/rs/assets/formats/NPCFormat.java
@@ -1,0 +1,720 @@
+package org.maxgamer.rs.assets.formats;
+
+import org.maxgamer.rs.util.BufferUtils;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Objects;
+
+/**
+ * @author netherfoam
+ */
+public class NPCFormat extends Format {
+    private String name = "null";
+    private String[] options = new String[5];
+    private int combatLevel = -1;
+
+    /**
+     * TODO: This default value doesn't appear right, because NPC's in the cache set it to '1'.
+     * TODO: implying that '1' is not the default value. I don't think this is size, personally.
+     */
+    private int size = 1;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public void setOption(int index, String option) {
+        this.options[index] = option;
+    }
+
+    public String getOption(int index) {
+        return options[index];
+    }
+
+    public int getLevel() {
+        return combatLevel;
+    }
+
+    public void setLevel(int combatLevel) {
+        this.combatLevel = combatLevel;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, options, combatLevel, size);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null || getClass() != obj.getClass()) {
+            return false;
+        }
+        final NPCFormat other = (NPCFormat) obj;
+        return Objects.equals(this.name, other.name)
+                && Objects.deepEquals(this.options, other.options)
+                && Objects.equals(this.combatLevel, other.combatLevel)
+                && Objects.equals(this.size, other.size);
+    }
+
+    @Override
+    public void encode(ByteArrayOutputStream out) throws IOException {
+        // Name
+        if(!"null".equals(name)) {
+            out.write((byte) (2));
+            out.write(name.getBytes());
+            out.write((byte) 0);
+        }
+
+        // Options
+        for(int i = 0; i < 5; i++) {
+            String option = options[i];
+
+            if(option == null) continue;
+
+            // NB: These can be signalled by both opcodes 150-154 and 30-34 inclusive
+            out.write((byte) (i + 150));
+            out.write(option.getBytes());
+            out.write((byte) 0);
+        }
+
+        if(combatLevel != -1) {
+            out.write(95);
+            out.write(combatLevel >> 8);
+            out.write(combatLevel);
+        }
+
+        /*if(size != 1) {
+            out.write(12);
+            out.write(size);
+        }*/
+    }
+
+    @Override
+    public void decode(int opcode, ByteBuffer bb, Stasis stasis) throws IOException {
+        switch (opcode) {
+            case 163:
+                bb.get();
+                break;
+            case 164:
+                bb.getShort();
+                bb.getShort();
+                break;
+            case 165:
+                bb.get();
+                break;
+            case 168:
+                bb.get();
+                break;
+        }
+        if (opcode != 1) {
+            if (opcode == 2) {
+                this.name = BufferUtils.readRS2String(bb);
+                return;
+            } else if (opcode != 12) {
+                if (opcode < 30 || opcode >= 35) {
+                    if (opcode == 40) {
+                        int i_1_ = (bb.get() & 0xFF);
+                        short[] aShortArray3166 = new short[i_1_];
+                        short[] aShortArray3201 = new short[i_1_];
+                        for (int i_2_ = 0; i_2_ < i_1_; i_2_++) {
+                            aShortArray3201[i_2_] = (short) (bb.getShort() & 0xFFFF);
+                            aShortArray3166[i_2_] = (short) (bb.getShort() & 0xFFFF);
+                        }
+                    } else if (opcode != 41) {
+                        if (opcode != 42) {
+                            if (opcode != 60) {
+                                if (opcode == 93) {
+                                        /* d.isVisibleOnMap = false; */
+                                } else if (opcode == 95) {
+                                    this.combatLevel = (bb.getShort() & 0xFFFF);
+                                    return;
+                                } else if (opcode != 97) {
+                                    if (opcode != 98) {
+                                        if (opcode == 99) {
+                                                /* d.aBoolean3210 = true; */
+                                        } else if (opcode == 100) {
+                                            bb.get();
+                                        } else if (opcode == 101) {
+                                            bb.get();
+                                        } else if (opcode == 102) {
+                                                /* d.headIcons = ( */
+                                            bb.getShort()/*
+                                                                                 * &
+                                                                                 * 0xFFFF
+                                                                                 * )
+                                                                                 */;
+                                        } else if (opcode == 103) {
+                                                /* d.anInt3235 = ( */
+                                            bb.getShort()/*
+                                                                                 * &
+                                                                                 * 0xFFFF
+                                                                                 * )
+                                                                                 */;
+                                        } else if (opcode != 106 && opcode != 118) {
+                                            if (opcode != 107) {
+                                                if (opcode == 109) {
+                                                        /*
+                                                         * d.aBoolean3169 =
+                                                         * false;
+                                                         */
+                                                } else if (opcode != 111) {
+                                                    if (opcode == 113) {
+                                                            /*
+                                                             * d.aShort3213 =
+                                                             * (short) (
+                                                             */
+                                                        bb.getShort()/*
+                                                                             * &
+                                                                             * 0xFFFF
+                                                                             * )
+                                                                             */;
+                                                            /*
+                                                             * d.aShort3237 =
+                                                             * (short) (
+                                                             */
+                                                        bb.getShort()/*
+                                                                             * &
+                                                                             * 0xFFFF
+                                                                             * )
+                                                                             */;
+                                                    } else if (opcode == 114) {
+                                                            /* d.aByte3215 = */
+                                                        bb.get();
+                                                            /* d.aByte3193 = */
+                                                        bb.get();
+                                                    } else if (opcode != 119) {
+                                                        if (opcode != 121) {
+                                                            if (opcode != 122) {
+                                                                if (opcode == 123) {
+                                                                        /*
+                                                                         * d.
+                                                                         * anInt3203
+                                                                         * = (
+                                                                         */
+                                                                    bb.getShort()/*
+                                                                                         * &
+                                                                                         * 0xFFFF
+                                                                                         * )
+                                                                                         */;
+                                                                } else if (opcode != 125) {
+                                                                    if (opcode == 127) {
+                                                                            /*
+                                                                             * d.
+                                                                             * renderEmote
+                                                                             * =
+                                                                             * (
+                                                                             */
+                                                                        bb.getShort()/*
+                                                                                             * &
+                                                                                             * 0xFFFF
+                                                                                             * )
+                                                                                             */;
+                                                                    } else if (opcode != 128) {
+                                                                        if (opcode == 134) {
+                                                                                /*
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3173
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.getShort()/*
+                                                                                                 * &
+                                                                                                 * 0xFFFF
+                                                                                                 * )
+                                                                                                 */;
+                                                                                /*
+                                                                                 * if
+                                                                                 * (
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3173
+                                                                                 * ==
+                                                                                 * 65535
+                                                                                 * )
+                                                                                 * {
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3173
+                                                                                 * =
+                                                                                 * -
+                                                                                 * 1
+                                                                                 * ;
+                                                                                 * }
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3212
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.getShort()/*
+                                                                                                 * &
+                                                                                                 * 0xFFFF
+                                                                                                 * )
+                                                                                                 */;
+                                                                                /*
+                                                                                 * if
+                                                                                 * (
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3212
+                                                                                 * ==
+                                                                                 * 65535
+                                                                                 * )
+                                                                                 * {
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3212
+                                                                                 * =
+                                                                                 * -
+                                                                                 * 1
+                                                                                 * ;
+                                                                                 * }
+                                                                                 */
+                                                                                /*
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3226
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.getShort()/*
+                                                                                                 * &
+                                                                                                 * 0xFFFF
+                                                                                                 * )
+                                                                                                 */;
+                                                                                /*
+                                                                                 * if
+                                                                                 * (
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3226
+                                                                                 * ==
+                                                                                 * 65535
+                                                                                 * )
+                                                                                 * {
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3226
+                                                                                 * =
+                                                                                 * -
+                                                                                 * 1
+                                                                                 * ;
+                                                                                 * }
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3179
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.getShort()/*
+                                                                                                 * &
+                                                                                                 * 0xFFFF
+                                                                                                 * )
+                                                                                                 */;
+                                                                                /*
+                                                                                 * if
+                                                                                 * (
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3179
+                                                                                 * ==
+                                                                                 * 65535
+                                                                                 * )
+                                                                                 * {
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3179
+                                                                                 * =
+                                                                                 * -
+                                                                                 * 1
+                                                                                 * ;
+                                                                                 * }
+                                                                                 */
+                                                                                /*
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3184
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.get()/*
+                                                                                             * &
+                                                                                             * 0xFF
+                                                                                             * )
+                                                                                             */;
+                                                                        } else if (opcode == 135) {
+                                                                                /*
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3214
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.get()/*
+                                                                                             * &
+                                                                                             * 0xFF
+                                                                                             * )
+                                                                                             */;
+                                                                                /*
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3178
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.getShort()/*
+                                                                                                 * &
+                                                                                                 * 0xFFFF
+                                                                                                 * )
+                                                                                                 */;
+                                                                        } else if (opcode != 136) {
+                                                                            if (opcode == 137) {
+                                                                                    /*
+                                                                                     * d
+                                                                                     * .
+                                                                                     * anInt3223
+                                                                                     * =
+                                                                                     * (
+                                                                                     */
+                                                                                bb.getShort()/*
+                                                                                                     * &
+                                                                                                     * 0xFFFF
+                                                                                                     * )
+                                                                                                     */;
+                                                                            } else if (opcode == 138) {
+                                                                                    /*
+                                                                                     * d
+                                                                                     * .
+                                                                                     * anInt3167
+                                                                                     * =
+                                                                                     */
+                                                                                bb.getShort()/*
+                                                                                                     * &
+                                                                                                     * 0xFFFF
+                                                                                                     */;
+                                                                            } else if (opcode != 139) {
+                                                                                if (opcode == 140) {
+                                                                                        /*
+                                                                                         * d
+                                                                                         * .
+                                                                                         * anInt3216
+                                                                                         * =
+                                                                                         */
+                                                                                    bb.get()/*
+                                                                                                     * &
+                                                                                                     * 0xFF
+                                                                                                     */;
+                                                                                } else if (opcode == 141) {
+                                                                                        /*
+                                                                                         * d
+                                                                                         * .
+                                                                                         * aBoolean3187
+                                                                                         * =
+                                                                                         * true
+                                                                                         * ;
+                                                                                         */
+                                                                                } else if (opcode == 142) {
+                                                                                        /*
+                                                                                         * d
+                                                                                         * .
+                                                                                         * anInt3200
+                                                                                         * =
+                                                                                         */
+                                                                                    bb.getShort()/*
+                                                                                                         * &
+                                                                                                         * 0xFFFF
+                                                                                                         */;
+                                                                                } else if (opcode != 143) {
+                                                                                    if (opcode < 150 || opcode >= 155) {
+                                                                                        if (opcode == 155) {
+                                                                                            bb.get();
+                                                                                            bb.get();
+                                                                                            bb.get();
+                                                                                            bb.get();
+                                                                                        } else if (opcode != 158) {
+                                                                                            if (opcode == 159) {
+                                                                                                    /*
+                                                                                                     * d
+                                                                                                     * .
+                                                                                                     * aByte3233
+                                                                                                     * =
+                                                                                                     * (
+                                                                                                     * byte
+                                                                                                     * )
+                                                                                                     * 0
+                                                                                                     * ;
+                                                                                                     */
+                                                                                            } else if (opcode != 160) {
+                                                                                                if (opcode != 161) {
+                                                                                                    if (opcode == 249) {
+                                                                                                        int i_3_ = (bb.get() & 0xFF);
+                                                                                                        for (int i_5_ = 0; i_3_ > i_5_; i_5_++) {
+                                                                                                            boolean bool = (bb.get() & 0xFF) == 1;
+                                                                                                            //bb.read24BitInt();
+                                                                                                            BufferUtils.getTriByte(bb);
+                                                                                                            //System.out.println("ScriptID " + i_6_);
+                                                                                                            if (!bool) {
+                                                                                                                bb.getInt();
+                                                                                                            } else {
+                                                                                                                BufferUtils.readRS2String(bb);
+                                                                                                            }
+                                                                                                            //System.out.println("Script NPC STRING: " + bb.readRS2String());
+                                                                                                        }
+                                                                                                    }
+                                                                                                } else {
+                                                                                                        /*
+                                                                                                         * d
+                                                                                                         * .
+                                                                                                         * aBoolean3190
+                                                                                                         * =
+                                                                                                         * true
+                                                                                                         * ;
+                                                                                                         */
+                                                                                                }
+                                                                                            } else {
+                                                                                                int i_7_ = (bb.get() & 0xFF);
+                                                                                                int[] anIntArray3219 = new int[i_7_];
+                                                                                                for (int i_8_ = 0; i_7_ > i_8_; i_8_++) {
+                                                                                                    anIntArray3219[i_8_] = (bb.getShort() & 0xFFFF);
+                                                                                                }
+                                                                                            }
+                                                                                        } else {
+                                                                                                /*
+                                                                                                 * d
+                                                                                                 * .
+                                                                                                 * aByte3233
+                                                                                                 * =
+                                                                                                 * (
+                                                                                                 * byte
+                                                                                                 * )
+                                                                                                 * 1
+                                                                                                 * ;
+                                                                                                 */
+                                                                                        }
+                                                                                    } else {
+                                                                                        this.options[opcode - 150] = BufferUtils.readRS2String(bb); //bb.readRS2String();
+                                                                                        return;
+                                                                                            /*
+                                                                                             * if
+                                                                                             * (
+                                                                                             * !
+                                                                                             * (
+                                                                                             * (
+                                                                                             * Class183
+                                                                                             * )
+                                                                                             * aClass183_3195
+                                                                                             * )
+                                                                                             * .
+                                                                                             * aBoolean2484
+                                                                                             * )
+                                                                                             * options
+                                                                                             * [
+                                                                                             * opcode
+                                                                                             * +
+                                                                                             * -
+                                                                                             * 150
+                                                                                             * ]
+                                                                                             * =
+                                                                                             * null
+                                                                                             * ;
+                                                                                             */
+                                                                                    }
+                                                                                } else {
+                                                                                        /*
+                                                                                         * d
+                                                                                         * .
+                                                                                         * aBoolean3196
+                                                                                         * =
+                                                                                         * true
+                                                                                         * ;
+                                                                                         */
+                                                                                }
+                                                                            } else {
+                                                                                    /*
+                                                                                     * d
+                                                                                     * .
+                                                                                     * anInt3164
+                                                                                     * =
+                                                                                     * (
+                                                                                     */
+                                                                                bb.getShort()/*
+                                                                                                     * &
+                                                                                                     * 0xFFFF
+                                                                                                     * )
+                                                                                                     */;
+                                                                            }
+                                                                        } else {
+                                                                                /*
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3181
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.get()/*
+                                                                                             * &
+                                                                                             * 0xFF
+                                                                                             * )
+                                                                                             */;
+                                                                                /*
+                                                                                 * d
+                                                                                 * .
+                                                                                 * anInt3227
+                                                                                 * =
+                                                                                 * (
+                                                                                 */
+                                                                            bb.getShort() /*
+                                                                                                 * &
+                                                                                                 * 0xFFFF
+                                                                                                 * )
+                                                                                                 */;
+                                                                        }
+                                                                    } else {
+                                                                        bb.get();
+                                                                    }
+                                                                } else {
+                                                                        /*
+                                                                         * d.
+                                                                         * direction
+                                                                         * =
+                                                                         */
+                                                                    bb.get();
+                                                                }
+                                                            } else {
+                                                                    /*
+                                                                     * d.anInt3182
+                                                                     * = (
+                                                                     */
+                                                                bb.getShort() /*
+                                                                                     * &
+                                                                                     * 0xFFFF
+                                                                                     * )
+                                                                                     */;
+                                                            }
+                                                        } else {
+                                                            int i_9_ = (bb.get() & 0xFF);
+                                                            for (int i_10_ = 0; (i_9_ > i_10_); i_10_++) {
+                                                                //(bb.get() & 0xFF);
+                                                                bb.get();
+                                                                int[] is = new int[3];
+                                                                is[0] = bb.get();
+                                                                is[1] = bb.get();
+                                                                is[2] = bb.get();
+                                                            }
+                                                        }
+                                                    } else {
+                                                            /* d.aByte3207 = */
+                                                        bb.get();
+                                                    }
+                                                } else {
+                                                        /*
+                                                         * d.aBoolean3172 =
+                                                         * false;
+                                                         */
+                                                }
+                                            } else {
+                                                    /* d.isClickable = false; */
+                                            }
+                                        } else {
+                                                /* d.configFileId = ( */
+                                            bb.getShort()/*
+                                                                                     * &
+                                                                                     * 0xFFFF
+                                                                                     * )
+                                                                                     */;
+                                                /*
+                                                 * if (d.configFileId == 65535)
+                                                 * { d.configFileId = -1; }
+                                                 * d.configId = (
+                                                 */
+                                            bb.getShort()/* & 0xFFFF) */;
+                                                /*
+                                                 * if (d.configId == 65535) {
+                                                 * d.configId = -1; }
+                                                 */
+                                            int i_12_ = -1;
+                                            if (opcode == 118) {
+                                                i_12_ = (bb.getShort() & 0xFFFF);
+                                                if (i_12_ == 65535) {
+                                                    i_12_ = -1;
+                                                }
+                                            }
+                                            int i_13_ = (bb.get() & 0xFF);
+                                            int[] childrenIds = new int[2 + i_13_];
+                                            for (int i_14_ = 0; i_14_ <= i_13_; i_14_++) {
+                                                childrenIds[i_14_] = (bb.getShort() & 0xFFFF);
+                                                if ((childrenIds[i_14_]) == 65535) {
+                                                    childrenIds[i_14_] = -1;
+                                                }
+                                            }
+                                            childrenIds[1 + i_13_] = i_12_;
+                                        }
+                                    } else {
+                                        bb.getShort()/* & 0xFFFF */;
+                                    }
+                                } else {
+                                    bb.getShort()/* & 0xFFFF */;
+                                }
+                            } else {
+                                int i_15_ = (bb.get() & 0xFF);
+                                int[] anIntArray3192 = new int[i_15_];
+                                for (int i_16_ = 0; i_16_ < i_15_; i_16_++) {
+                                    anIntArray3192[i_16_] = (bb.getShort() & 0xFFFF);
+                                }
+                            }
+                        } else {
+                            int i_17_ = (bb.get() & 0xFF);
+                            byte[] aByteArray3205 = new byte[i_17_];
+                            for (int i_18_ = 0; i_18_ < i_17_; i_18_++) {
+                                aByteArray3205[i_18_] = bb.get();
+                            }
+                        }
+                    } else {
+                        int i_19_ = (bb.get() & 0xFF);
+                        short[] aShortArray3183 = new short[i_19_];
+                        short[] aShortArray3204 = new short[i_19_];
+                        for (int i_20_ = 0; i_20_ < i_19_; i_20_++) {
+                            aShortArray3183[i_20_] = (short) (bb.getShort() & 0xFFFF);
+                            aShortArray3204[i_20_] = (short) (bb.getShort() & 0xFFFF);
+                        }
+                    }
+                } else {
+                    this.options[opcode - 30] = BufferUtils.readRS2String(bb);
+                    return;
+                }
+            } else {
+                this.size = (bb.get() & 0xFF);
+                return;
+            }
+        } else {
+            int i_21_ = (bb.get() & 0xFF);
+            int[] anIntArray3230 = new int[i_21_];
+            for (int i_22_ = 0; i_21_ > i_22_; i_22_++) {
+                anIntArray3230[i_22_] = (bb.getShort() & 0xFFFF);
+                if (anIntArray3230[i_22_] == 65535) {
+                    anIntArray3230[i_22_] = -1;
+                }
+            }
+        }
+
+        stasis.preserve();
+    }
+}

--- a/src/main/java/org/maxgamer/rs/model/entity/mob/npc/NPC.java
+++ b/src/main/java/org/maxgamer/rs/model/entity/mob/npc/NPC.java
@@ -93,6 +93,7 @@ public class NPC extends Mob implements Interactable {
         this.model = new NPCModel(this.definition);
         this.mask = new NPCUpdateMask(this, new NPCMovementUpdate());
         this.skills = new SkillSet(this);
+        this.spawn = l;
 
         NPCType d = getDefinition();
         this.skills.setLevel(SkillType.ATTACK, d.getAttackLevel());

--- a/src/main/java/org/maxgamer/rs/model/item/inventory/BankContainer.java
+++ b/src/main/java/org/maxgamer/rs/model/item/inventory/BankContainer.java
@@ -7,6 +7,17 @@ import org.maxgamer.rs.structure.configs.ConfigSection;
  * @author netherfoam
  */
 public class BankContainer extends Container {
+    /**
+     * TODO: Duplication bug. Conditions:
+     * * Noting = true
+     * slot[length-3] = coins (200)
+     * slot[length-2] = coins (200)
+     * slot[length-1] = hatchet (80)
+     *
+     * 1. Withdraw all on coins
+     * 2. Deposit all coins (hatchet will duplicate stacks)
+     * 3. Rinse and repeat for infinite items
+     */
     public static final int SIZE = 516;
     public static final int TABS = 11;
 

--- a/src/main/java/org/maxgamer/rs/network/io/rawhandler/CacheRequestHandler.java
+++ b/src/main/java/org/maxgamer/rs/network/io/rawhandler/CacheRequestHandler.java
@@ -113,7 +113,10 @@ public class CacheRequestHandler extends RawHandler {
                 case 3: //the client is logged out
                     break;
 
-                case 4: //A new encryption byte is being used
+                case 4:
+                    // A new encryption byte is being used.
+                    // Oddly, this seems to be only sent when the client has an error in the cache.
+
                     Log.info("Connection encryption byte set");
                     /* byte encryptionByte = *///in.readByte();
                     //The other 2 bytes are padding

--- a/src/test/java/org/maxgamer/rs/fs/AssetStorageRealityTest.java
+++ b/src/test/java/org/maxgamer/rs/fs/AssetStorageRealityTest.java
@@ -24,6 +24,7 @@ public class AssetStorageRealityTest {
         storage = new AssetStorage(new File("cache")) {
             @Override
             public AssetWriter writer(int idx) throws IOException {
+                // We don't want to accidentally modify the real cache when performing these tests
                 throw new IllegalStateException("Can't touch this");
             }
         };
@@ -87,5 +88,4 @@ public class AssetStorageRealityTest {
             }
         }
     }
-
 }

--- a/src/test/java/org/maxgamer/rs/fs/AssetWriterTest.java
+++ b/src/test/java/org/maxgamer/rs/fs/AssetWriterTest.java
@@ -1,0 +1,203 @@
+package org.maxgamer.rs.fs;
+
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.maxgamer.rs.assets.AssetStorage;
+import org.maxgamer.rs.assets.MultiAsset;
+import org.maxgamer.rs.assets.codec.RSCompression;
+import org.maxgamer.rs.assets.codec.asset.Asset;
+import org.maxgamer.rs.assets.codec.asset.AssetReference;
+import org.maxgamer.rs.assets.codec.asset.SubAssetReference;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Random;
+
+/**
+ * @author netherfoam
+ */
+public class AssetWriterTest {
+    private File folder = new File("test_cache");
+
+    private byte[] data(int size) {
+        Random r = new Random(0);
+        byte[] data = new byte[size];
+        r.nextBytes(data);
+
+        return data;
+    }
+
+    private byte[] unbuffer(ByteBuffer buffer) {
+        byte[] data = new byte[buffer.remaining()];
+        buffer.get(data);
+
+        return data;
+    }
+
+    @Before
+    public void init() throws IOException {
+        if(folder.exists()) {
+            for(File file : folder.listFiles()) {
+                file.delete();
+            }
+        }
+
+        folder.mkdir();
+    }
+
+    @After
+    public void destroy() throws IOException {
+        for(File f : folder.listFiles()) {
+            if(!f.delete()) f.deleteOnExit();
+        }
+        if(!folder.delete()) folder.deleteOnExit();
+    }
+
+    @Test
+    public void writeBasic() throws IOException {
+        // Test that we can write and overwrite an asset
+        AssetStorage storage = AssetStorage.create(folder);
+
+        Asset asset = Asset.create(null, RSCompression.NONE, 1, ByteBuffer.wrap("Hello World".getBytes()));
+        AssetReference reference = AssetReference.create(1);
+
+        storage.writer(0)
+                .write(0, reference, asset)
+                .commit();
+
+        Assert.assertArrayEquals("payloads should match", unbuffer(asset.getPayload()), unbuffer(storage.read(0, 0).getPayload()));
+
+        asset.setPayload(ByteBuffer.wrap("Goodbye World".getBytes()));
+        storage.writer(0)
+                .write(0, reference, asset)
+                .commit();
+
+        Assert.assertArrayEquals("payloads should match", unbuffer(asset.getPayload()), unbuffer(storage.read(0, 0).getPayload()));
+    }
+
+    @Test
+    public void writeNewVersion() throws IOException {
+        // Test that we can skip bothering with the AssetReference, if we want to just reuse the existing one
+        AssetStorage storage = AssetStorage.create(folder);
+
+        Asset asset = Asset.create(null, RSCompression.NONE, 1, ByteBuffer.wrap("Hello World".getBytes()));
+        AssetReference reference = AssetReference.create(1);
+
+        storage.writer(0)
+                .write(0, reference, asset)
+                .commit();
+
+        asset.setPayload(ByteBuffer.wrap("Goodbye World".getBytes()));
+        storage.writer(0)
+                .write(0, asset)
+                .commit();
+
+        // Assert that our files match and our version incremented
+        AssetReference newReference = storage.properties(0, 0);
+        Assert.assertArrayEquals("payloads should match", unbuffer(asset.getPayload()), unbuffer(storage.read(0, 0).getPayload()));
+        Assert.assertTrue("version should increase", newReference.getVersion() > reference.getVersion());
+
+        storage.writer(0)
+                .write(1, asset)
+                .commit();
+
+        // Assert that our payloads match and our version is > 0
+        Assert.assertArrayEquals("payloads should match", unbuffer(asset.getPayload()), unbuffer(storage.read(0, 1).getPayload()));
+        Assert.assertTrue("version should increase", newReference.getVersion() > 0);
+    }
+
+    @Test
+    public void writeMultiAsset() throws IOException {
+        AssetStorage storage = AssetStorage.create(folder);
+
+        SubAssetReference child = new SubAssetReference(5, 0);
+        AssetReference reference = AssetReference.create(1, child);
+        MultiAsset multi = new MultiAsset(reference);
+        ByteBuffer content = ByteBuffer.wrap("Hello World".getBytes());
+        multi.put(5, content);
+
+        storage.writer(0)
+                .write(0, multi)
+                .commit();
+
+        multi = storage.archive(0, 0);
+        Assert.assertArrayEquals("expect content to match", unbuffer(content), unbuffer(multi.get(5)));
+
+        // Now we test overwriting it
+        content = ByteBuffer.wrap("Goodbye World".getBytes());
+        multi.put(5, content);
+
+        storage.writer(0)
+                .write(0, multi)
+                .commit();
+
+        multi = storage.archive(0, 0);
+
+        Assert.assertArrayEquals("expect content to match", unbuffer(content), unbuffer(multi.get(5)));
+    }
+
+    @Test
+    public void writeSubAsset() throws IOException {
+        AssetStorage storage = AssetStorage.create(folder);
+
+        // Write: create it in the cache
+        ByteBuffer content = ByteBuffer.wrap("Hello World".getBytes());
+        storage.writer(0)
+                .write(0, 5, content)
+                .commit();
+
+        Assert.assertArrayEquals("Expect content to match", unbuffer(content), unbuffer(storage.archive(0, 0).get(5)));
+
+        // Write: re-create it in the cache
+        content.position(0);
+        storage.writer(0)
+                .write(0, 5, content)
+                .commit();
+
+        Assert.assertArrayEquals("Expect content to match", unbuffer(content), unbuffer(storage.archive(0, 0).get(5)));
+
+        // Write: create two in the cache
+        ByteBuffer brother = ByteBuffer.wrap("I am Brother".getBytes());
+        ByteBuffer sister = ByteBuffer.wrap("I am Sister".getBytes());
+        storage.writer(0)
+                .write(1, 7, brother)
+                .write(1, 8, sister)
+                .commit();
+
+        Assert.assertArrayEquals("Expect content to match", unbuffer(brother), unbuffer(storage.archive(0, 1).get(7)));
+        Assert.assertArrayEquals("Expect content to match", unbuffer(sister), unbuffer(storage.archive(0, 1).get(8)));
+    }
+
+    @Test
+    public void deleteSubAsset() throws IOException {
+        AssetStorage storage = AssetStorage.create(folder);
+
+        // Write: create it in the cache
+        ByteBuffer content = ByteBuffer.wrap("Hello World".getBytes());
+        storage.writer(0)
+                .write(0, 5, content)
+                .commit();
+
+        storage.writer(0)
+                .delete(0, 5)
+                .commit();
+
+        Assert.assertNull("Expect child to be erased", storage.archive(0, 0).get(5));
+    }
+
+    @Test
+    public void deleteQueuedWriteSubAsset() throws IOException {
+        AssetStorage storage = AssetStorage.create(folder);
+
+        ByteBuffer content = ByteBuffer.wrap("Hello World".getBytes());
+        storage.writer(0)
+                .write(0, 5, content) // Write file
+                .delete(0, 5) // Actually nevermind
+                .commit();
+
+        Assert.assertNull("Expect child not to be written", storage.archive(0, 0).get(5));
+    }
+}

--- a/src/test/java/org/maxgamer/rs/fs/FormatTest.java
+++ b/src/test/java/org/maxgamer/rs/fs/FormatTest.java
@@ -1,0 +1,38 @@
+package org.maxgamer.rs.fs;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.maxgamer.rs.assets.AssetStorage;
+import org.maxgamer.rs.assets.IDX;
+import org.maxgamer.rs.assets.MultiAsset;
+import org.maxgamer.rs.assets.formats.ItemFormat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+/**
+ * @author netherfoam
+ */
+public class FormatTest {
+    @Test
+    public void itemTest() throws IOException {
+        AssetStorage storage = new AssetStorage(new File("cache"));
+
+        final int id = 995; // Coins
+        MultiAsset a = storage.archive(IDX.ITEMS, id >> 8);
+        ByteBuffer bb = a.get(id & 0xFF);
+
+        ItemFormat format = new ItemFormat();
+        format.decode(bb.asReadOnlyBuffer());
+
+        ByteBuffer encoded = format.encode();
+        Assert.assertEquals(encoded.remaining(), bb.remaining());
+
+        format.setInventoryOption(3, "Lick");
+        ItemFormat updated = new ItemFormat();
+        updated.decode(format.encode());
+
+        Assert.assertEquals("expect Lick", "Lick", updated.getInventoryOption(3));
+    }
+}

--- a/src/test/java/org/maxgamer/rs/fs/FormatTest.java
+++ b/src/test/java/org/maxgamer/rs/fs/FormatTest.java
@@ -6,6 +6,7 @@ import org.maxgamer.rs.assets.AssetStorage;
 import org.maxgamer.rs.assets.IDX;
 import org.maxgamer.rs.assets.MultiAsset;
 import org.maxgamer.rs.assets.formats.ItemFormat;
+import org.maxgamer.rs.assets.formats.NPCFormat;
 
 import java.io.File;
 import java.io.IOException;
@@ -34,5 +35,25 @@ public class FormatTest {
         updated.decode(format.encode());
 
         Assert.assertEquals("expect Lick", "Lick", updated.getInventoryOption(3));
+    }
+
+    @Test
+    public void npcTest() throws IOException {
+        AssetStorage storage = new AssetStorage(new File("cache"));
+
+        final int id = 3381; // Doris
+        MultiAsset a = storage.archive(IDX.NPCS, id >> 7);
+        ByteBuffer bb = a.get(id & 0x7F);
+
+        NPCFormat format = new NPCFormat();
+        format.decode(bb.asReadOnlyBuffer());
+
+        ByteBuffer encoded = format.encode();
+
+        NPCFormat other = new NPCFormat();
+        other.decode(encoded);
+        encoded.position(0);
+
+        Assert.assertEquals(format, other);
     }
 }


### PR DESCRIPTION
feat(format): stub for format handling, for custom items etc
fix(assets): calculate checksums without version bytes
fix(assets): cached storage multi assets now safe from modification
feat(assets): easier ways of writing assets to store
fix(npc): spawning an npc now sets spawn location
test(assets): test checksums on files delivered by protocol
test(assets): tests for asset writer methods
